### PR TITLE
add merch to navbar on Join MHC page

### DIFF
--- a/howtojoin.html
+++ b/howtojoin.html
@@ -21,6 +21,7 @@
     <a href="#main">Join MHC</a>
     <a href="contact.html">Contact</a>
     <a href="projects.html">Projects</a>
+    <a href="merch.html">Merch</a>
   </div>
   <div id="main">
     <div class="content join">


### PR DESCRIPTION
The navbar on the [howtojoin.html](https://memphis-hackclub.github.io/the-new-website/howtojoin.html#main) didn't have a link to the merch page.